### PR TITLE
replace deprecated function set-output for GITHUB_OUTPUT

### DIFF
--- a/src/set-output.sh
+++ b/src/set-output.sh
@@ -7,4 +7,4 @@ value="$2"
 value="${value//'%'/'%25'}"
 value="${value//$'\n'/'%0A'}"
 value="${value//$'\r'/'%0D'}"
-echo "::set-output name=$name::$value"
+echo "${name}=${value}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
As explained in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Use `GITHUB_OUTPUT` 


<img width="1255" alt="image" src="https://github.com/WillAbides/benchdiff-action/assets/2871786/002c801e-a94d-4106-8b28-8805eaf1cd3f">

