### PR TITLE
ci fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     name: cibuild
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: script/generate --check
       - run: script/lint
   text-bench:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,12 @@ jobs:
   text-bench:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           repository: golang/text
+          ref: v0.3.6
           fetch-depth: 0
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: "~1.15"
       - uses: WillAbides/benchdiff-action@v0

--- a/src/set-output.sh
+++ b/src/set-output.sh
@@ -7,4 +7,4 @@ value="$2"
 value="${value//'%'/'%25'}"
 value="${value//$'\n'/'%0A'}"
 value="${value//$'\r'/'%0D'}"
-echo "${name}=${value}" >> $GITHUB_OUTPUT
+echo "${name}=${value}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This fixes ci by quoting "$GITHUB_OUTPUT" and by setting a ref for the text benchmark. Also updates some actions.